### PR TITLE
Putting content on the home page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Introduction to SLE Base Container Images
-slug: introduction
 ---
 
 SLE Base Container Image (SLE BCI) are minimal SUSE Linux Enterprise Server

--- a/data/menu/main.yml
+++ b/data/menu/main.yml
@@ -5,7 +5,7 @@ main:
     # icon: "gdoc_notification"
     sub:
       - name: Introduction
-        ref: "/documentation/introduction"
+        ref: "/"
       - name: Why SLE BCI
         ref: "/documentation/why"
       - name: General purpose BCI


### PR DESCRIPTION
This moved the introduction to be the homepage content. It is
still in the navigation as the introduction under documentation.

The home page for the generated site was blank. The introduction seemed like the best candidate for the content to use.