### PR TITLE
Correct wording to use "SLE BCI" consistently

### DIFF
--- a/content/documentation/why.adoc
+++ b/content/documentation/why.adoc
@@ -42,6 +42,6 @@ applications.
 
 == Redistribution
 
-BCIs are covered by a permissive
+SLE BCIs are covered by a permissive
 https://www.suse.com/licensing/eula/#bci[EULA] that allows you to
-redistribute custom container images based on a BCI.
+redistribute custom container images based on a SLE BCI.

--- a/content/guides/adding-users.adoc
+++ b/content/guides/adding-users.adoc
@@ -3,7 +3,7 @@ title: Adding Users to SLE BCI Micro and Minimal
 ---
 
 {{< hint type="note" >}}
-This guide will demonstrate how to add users to the SLE BCI Micro and SLE Minimal
+This guide will demonstrate how to add users to the SLE BCI Micro and SLE BCI Minimal
 images, without having the `useradd` binary installed.
 {{< /hint >}}
 
@@ -102,7 +102,7 @@ USER $user
 ----
 
 Build your container image using your favorite container runtime using the
-`--build-arg` parameter as in link:#_Switch_to_using_the_BusyBox_BCI[Switch to
+`--build-arg` parameter as in link:#_Switch_to_using_the_SLE_BCI[Switch to
 using the BusyBox SLE BCI].
 
 

--- a/content/guides/adding-users.adoc
+++ b/content/guides/adding-users.adoc
@@ -26,7 +26,7 @@ manager in your final image and additionally:
 
 2. your application runs with POSIX `sh` and not just Bash
 
-then consider using the SLE BCI BusyBox image instead. It is even smaller than BCI
+then consider using the SLE BCI BusyBox image instead. It is even smaller than SLE BCI
 Micro and ships the BusyBox implementation of `useradd`. Adding a new user in
 BusyBox is straightforward:
 

--- a/content/guides/adding-users.adoc
+++ b/content/guides/adding-users.adoc
@@ -1,24 +1,24 @@
 ---
-title: Adding Users to BCI Micro and Minimal
+title: Adding Users to SLE BCI Micro and Minimal
 ---
 
 {{< hint type="note" >}}
-This guide will demonstrate how to add users to the BCI Micro and Minimal
+This guide will demonstrate how to add users to the SLE BCI Micro and SLE Minimal
 images, without having the `useradd` binary installed.
 {{< /hint >}}
 
 
 == Background
 
-The BCI Micro and Minimal images are tailored towards providing a small
+The SLE BCI Micro and Minimal images are tailored towards providing a small
 footprint and thus do not ship the `useradd` binary. While this reduces the
 image size, creating new users inside containers based on BCI Micro or Minimal
 involves a few additional steps.
 
 
-=== Switch to using the Busybox BCI
+=== Switch to using the BusyBox SLE BCI
 
-BCI Minimal and BCI Micro are lightweight deployment images without a package
+SLE BCI Minimal and SLE BCI Micro are lightweight deployment images without a package
 manager and tailored for specific use cases. If you do not require a package
 manager in your final image and additionally:
 
@@ -26,9 +26,9 @@ manager in your final image and additionally:
 
 2. your application runs with POSIX `sh` and not just Bash
 
-then consider using the BCI Busybox image instead. It is even smaller than BCI
-Micro and ships the Busybox implementation of `useradd`. Adding a new user in
-Busybox is straightforward:
+then consider using the SLE BCI BusyBox image instead. It is even smaller than BCI
+Micro and ships the BusyBox implementation of `useradd`. Adding a new user in
+BusyBox is straightforward:
 
 [source,Dockerfile]
 ----
@@ -67,8 +67,8 @@ nerdctl build --build-arg user=rancher .
 === Using the Base Container to create the User Account
 
 We can utilize a multistage build to create the user in a container that
-provides the `useradd` binary and then copy all necessary files into BCI
-Micro or BCI Minimal. This is achieved using the following `Dockerfile`:
+provides the `useradd` binary and then copy all necessary files into SLE BCI
+Micro or SLE BCI Minimal. This is achieved using the following `Dockerfile`:
 
 [source,Dockerfile]
 ----
@@ -102,16 +102,16 @@ USER $user
 ----
 
 Build your container image using your favorite container runtime using the
-`--build-arg` parameter as in link:#_Switch_to_using_the_Busybox_BCI[Switch to
-using the Busybox BCI].
+`--build-arg` parameter as in link:#_Switch_to_using_the_BusyBox_BCI[Switch to
+using the BusyBox SLE BCI].
 
 
-=== Using Busybox to create the User Account
+=== Using BusyBox to create the User Account
 
-We can leverage the `adduser` implementation from Busybox to create new users
-in BCI Minimal, by installing Busybox inside the Minimal image and then
+We can leverage the `adduser` implementation from BusyBox to create new users
+in SLE BCI Minimal, by installing BusyBox inside the Minimal image and then
 executing its `adduser`. This will *not* work in the Micro image as it lacks
-`rpm` to install Busybox.
+`rpm` to install BusyBox.
 
 {{< hint type="Warning" >}}
 This approach will leave two rpm files inside a layer of your final container
@@ -119,8 +119,8 @@ image, thereby making it slightly bigger than necessary. Consider squashing the
 layers to remove this overhead.
 {{< /hint >}}
 
-We utilize the BCI Base container once again to download the rpms of Busybox and
-`libsepol1` (a dependency of Busybox), copy both rpms into the Minimal image,
+We utilize the SLE BCI Base container once again to download the rpms of BusyBox and
+`libsepol1` (a dependency of BusyBox), copy both rpms into the Minimal image,
 add the user and remove both packages afterwards:
 
 [source,Dockerfile]

--- a/content/guides/adding-users.adoc
+++ b/content/guides/adding-users.adoc
@@ -102,7 +102,7 @@ USER $user
 ----
 
 Build your container image using your favorite container runtime using the
-`--build-arg` parameter as in link:#_Switch_to_using_the_SLE_BCI[Switch to
+`--build-arg` parameter as in link:#_switch_to_using_the_busybox_sle_bci[Switch to
 using the BusyBox SLE BCI].
 
 

--- a/content/guides/building-on-top-of-bci/_index.adoc
+++ b/content/guides/building-on-top-of-bci/_index.adoc
@@ -4,13 +4,13 @@ slug: building-on-top-of-bci
 resources:
   - name: registry.opensuse.org_bci_ruby
     src: "registry.opensuse.org_bci_ruby.png"
-    title: Ruby BCI on registry.opensuse.org
+    title: Ruby SLE BCI on registry.opensuse.org
   - name: obs_repository_add
     src: "obs_repository_add.png"
     title: repository view
   - name: registry.opensuse.org_bci_ruby_build_tag
     src: "registry.opensuse.org_bci_ruby_build_tag.png"
-    title: Ruby BCI on registry.opensuse.org with the build tag underlined
+    title: Ruby SLE BCI on registry.opensuse.org with the build tag underlined
 ---
 
 {{< hint title=Summary >}}
@@ -78,7 +78,7 @@ https://osinside.github.io/kiwi/[kiwi].
 The Open Build Service supports building container images using a
 `Dockerfile`. However, you need to pay particular attention when
 creating offline builds with the Open Build Service. To build a
-container image based on BCI follow the steps below.
+container image based on SLE BCI follow the steps below.
 
 1. Create a new package for a container image in an appropriate
    project where you have write access using

--- a/content/guides/container-suseconnect.adoc
+++ b/content/guides/container-suseconnect.adoc
@@ -70,7 +70,7 @@ nerdctl run --rm registry.suse.com/suse/sle15:latest bash -c \
 
 {{< /tab >}} {{< /tabs >}}
 
-If you are running a container based on a BCI, mount
+If you are running a container based on a SLE BCI, mount
 `SCCcredentials` (and optionally `/etc/SUSEConnect`) in the correct
 destination. The following example shows how to mount `SCCcredentials`
 in the current working directory:

--- a/content/guides/dev-containers/index.adoc
+++ b/content/guides/dev-containers/index.adoc
@@ -1,5 +1,5 @@
 ---
-Title: How To Use BCIs As VScode Development Containers
+Title: How To Use SLE BCIs As VScode Development Containers
 slug: vscode-dev-containers
 resources:
   - name: vscode
@@ -15,7 +15,7 @@ resources:
 Visual Studio Code has a feature called
 https://code.visualstudio.com/docs/remote/create-dev-container[Development
 Containers]. This is part of the built-in functionality to work with
-remote containers. The SLE Language Stack BCIs make a great choice to
+remote containers. The Language Stack SLE BCIs make a great choice to
 use as a development environment.
 
 == Why Use The SLE BCI In Development Containers
@@ -23,8 +23,8 @@ use as a development environment.
 There are two reasons the BCI language stack containers are useful for
 development.
 
-First, you develop in the same environment as when you use a BCI
-language stack image to build or run your application. Being able to
+First, you develop in the same environment as when you use a Language
+Stack SLE BCI to build or run your application. Being able to
 develop and build or run your application in the same environment setup
 enables you to discover quirks and issues that are related to the way
 your application works in the environment.
@@ -70,7 +70,7 @@ present you with an option to use a Development Container.
 There are two ways to specify where to get the container from. You can
 point it at an image or you can point it at a _Dockerfile_ to build the
 image from. Since VS Code needs some additional packages installed you
-can't simply point it at a BCI image.
+can't simply point it at a SLE BCI image.
 
 To illustrate using the `Dockerfile` method we can look at a setup for
 the Go programming language. A `Dockerfile` placed in the
@@ -85,7 +85,7 @@ RUN zypper --non-interactive install -y tar git gzip
 ----
 
 VS Code needs git, gzip, and tar installed which are not present in the
-Go BCI image by default.
+Go SLE BCI image by default.
 
 While this example is targeted at Go, it will work for other languages
 where there is a link:{{< relref

--- a/content/guides/use-with-golang.adoc
+++ b/content/guides/use-with-golang.adoc
@@ -3,9 +3,9 @@ Title: Building and Deploying Go Applications
 slug: use-with-golang
 ---
 
-There is https://registry.suse.com/static/bci/golang/index.html[a SLE
-BCI that can be used with the Go programming language]. There are a
-couple different recommended methods to work with the Go BCI.
+There is https://registry.suse.com/static/bci/golang/index.html[a
+SLE BCI that can be used with the Go programming language]. There are a
+couple different recommended methods to work with the Go SLE BCI.
 
 == Don't Ship The Compiler
 
@@ -71,10 +71,10 @@ Additional settings like exposing network ports or running as a
 non-root user can be specified in the last step below the `FROM
 scratch` line.
 
-=== Building for BCI
+=== Building for SLE BCI
 
 Applications that require external libraries or CA certificates cannot
-be deployed into a `scratch` image. A SLE General Purpose BCI should
+be deployed into a `scratch` image. A General Purpose SLE BCI should
 be used instead. The above `Dockerfile` has to be slightly adjusted
 in this case:
 
@@ -103,7 +103,7 @@ COPY --from=build /hello-world /usr/local/bin/hello-world
 CMD ["/usr/local/bin/hello-world"]
 ----
 
-The above example uses the BCI micro image as the deployment image for
+The above example uses the SLE BCI micro image as the deployment image for
 the resulting application. This is just one of the options, other
 options can be found in the section about the link:{{< relref
-"documentation/general-purpose-bci.adoc" >}}[General Purpose BCI].
+"documentation/general-purpose-bci.adoc" >}}[General Purpose SLE BCI].

--- a/content/guides/verify-with-cosign.adoc
+++ b/content/guides/verify-with-cosign.adoc
@@ -10,9 +10,9 @@ the supply chain security. As an alternative to the existing solutions, it is
 possible to use https://github.com/SigStore/cosign[Cosign] for verifying
 container images.
 
-== Verifying BCIs with Cosign
+== Verifying SLE BCI with Cosign
 
-To verify a BCI, run Cosign in the container. The command below fetches the
+To verify a SLE BCI image, run Cosign in the container. The command below fetches the
 signing key from the SUSE server and uses it to verify the latest BCI-Base container
 image.
 
@@ -40,10 +40,10 @@ image.
 ]
 ----
 
-The signing key can be used to verify all BCI container images, and it also
+The signing key can be used to verify all SLE BCI container images, and it also
 ships with SLE 15 (the `/usr/share/container-keys/suse-container-key.pem` file).
 
-You can also check BCI container images against
+You can also check SLE BCI container images against
 https://github.com/sigstore/rekor[rekor], the immutable tamper resistant
 ledger. For example:
 


### PR DESCRIPTION
SUSE BCI, SLE-BCI, BCI should all be standardized to SLE BCI.
- Leaving out the FAQ as that is going to be moved to suse.com.
- Fixing Busybox -> BusyBox typo