### PR TITLE
Fix wrong character in URL

### DIFF
--- a/content/guides/verify-sle-bci.adoc
+++ b/content/guides/verify-sle-bci.adoc
@@ -19,7 +19,7 @@ image.
 [source,ShellSession]
 ----
 > podman run --rm -it gcr.io/projectsigstore/cosign verify \
-    --key https://ftp.suse.com/pub/projects/security/keys/container–key.pem \
+    --key https://ftp.suse.com/pub/projects/security/keys/container-key.pem \
     registry.suse.com/bci/bci-base:latest | tail -1 | jq
 
 [
@@ -50,7 +50,7 @@ ledger. For example:
 [source,ShellSession]
 ----
 > podman run --rm -it -e COSIGN_EXPERIMENTAL=1 gcr.io/projectsigstore/cosign \
-    verify --key https://ftp.suse.com/pub/projects/security/keys/container–key.pem \
+    verify --key https://ftp.suse.com/pub/projects/security/keys/container-key.pem \
     registry.suse.com/bci/bci-base:latest | tail -1 | jq
 [
   {
@@ -150,7 +150,7 @@ Fetch the public key used to sign SLE BCIs from https://www.suse.com/support/sec
 
 [source,ShellSession]
 ----
-> sudo curl -s https://ftp.suse.com/pub/projects/security/keys/container–key.pem \
+> sudo curl -s https://ftp.suse.com/pub/projects/security/keys/container-key.pem \
     -o /usr/share/pki/containers/suse-container-key.pem
 ----
 


### PR DESCRIPTION
The URLs are returning 404, as the character used is not `-`, although it looks like it.

Previously:
```
curl https://ftp.suse.com/pub/projects/security/keys/container–key.pem
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

After these changes:
```
$ curl -s https://ftp.suse.com/pub/projects/security/keys/container-key.pem
-----BEGIN PUBLIC KEY-----
MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAxfZssLE2jeY1swPb5WGe
8C/FWKmIxlGLm9amCNdgheAn8RzuM8slA+TJefAQnrUnC4Qn9ykjQZjH6o2e2ueA
KFdgOdHnlS2d6lETB8dd4O8HYDJx0CEk2SCbAKVuzLbcbP4ug/QDc+Bm8ldxfc+D
GnLVRAt85brSTnfgOHY1PbQ1JAV+ByibbjCZuFmw4gIkMzeiy3M4wJZwblFM4a3s
X2bW/6GWaGz6AMOjCyAPI6shyG5wHZM7OvJJ8lfhXRTZo4Cc5qC0Nyq9Xu3O6DmV
opIajhHc36kdcetmd7TB5OSbQZCLyReAF75LV74y8960+44NptR62hdw1ovCJMfV
mU6m+k/MsN8AIyRFR6dNF9wTOKi67OpPtybiRufCfMvD4VEeoINzEJytToq2XGSc
+hIxtmPOhqDKHH0As113sjTqqo20Ik233x9FFeTFD8Or7ahpqjiv5YCufk9AoQbC
xMIjrK9RkQYgW4RycgvXGASobwN8EE+OsMcyMUER/pdCtQhTQCc1jYLt85VhfEkC
4k9szMB8eZrdV9re/Ku6vnCeXRR5yn2NWKO88U4HfxEpJv5s2uFJi37+x/v9w7Uh
+864W/9NexXg/JFNsvh0Kmxsbi3ZegaouLyrMCHwSA3ByBZ2yCf2VuFPyUCNEZOH
Owi0oc9TgY1yopjsTneyGaMCAwEAAQ==
-----END PUBLIC KEY-----
```